### PR TITLE
REMOVE CODECOV FROM TRAVIS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,3 @@ r_packages:
   - rgdal
   - roxygen2
   - rmarkdown
-
-r_github_packages: 
-  - jimhester/covr
-
-after_success:
-  - Rscript -e 'covr::codecov()'


### PR DESCRIPTION
Not sure what codecov is ... removing so it doesn't break/complicate the travis builds and reports