### PR TITLE
Improve attempts functionality w/in `crwMLE`

### DIFF
--- a/R/crawl-internal.R
+++ b/R/crawl-internal.R
@@ -207,3 +207,20 @@ getSD <- function(x){
 	if(any(!is.na(d))) return(max(d, na.rm=TRUE))
 	else return(0)
 }
+
+check_fit <- function(mle) {
+  checkMLE <- inherits(mle, 'try-error')
+  checkConv <-
+    ifelse(inherits(mle, 'try-error'), 1, mle$convergence > 0)
+  
+  C.tmp <- try(2 * solve(mle$hessian), silent = TRUE)
+  if (inherits(C.tmp, "try-error")) {
+    checkCovar <- 1
+    checkDiag <- 1
+  } else {
+    checkCovar <- 0
+    checkDiag <- ifelse(any(diag(C.tmp) <= 0), 1, 0)
+  }
+  return(sum(checkMLE, checkConv, checkCovar, checkDiag) > 0)
+}
+

--- a/R/crwMLE.R
+++ b/R/crwMLE.R
@@ -342,9 +342,10 @@ crwMLE = function(mov.model=~1, err.model=NULL, activity=NULL, drift=FALSE,
   }
   
   if (checkFit) {
-    return(paste("crwMLE failed. Try increasing attempts or changing user",
+    return(simpleError(
+      paste("crwMLE failed. Try increasing attempts or changing user",
                "provided sd values. Other parameter values may need to be changed.",
-               "Good Luck!"))
+               "Good Luck!")))
   }
     par <- fixPar
     par[is.na(fixPar)] <- mle$par

--- a/R/crwMLE.R
+++ b/R/crwMLE.R
@@ -48,6 +48,17 @@
 #' the crwFit object will be a list with the results of the simulated annealing
 #' optimization.
 #' 
+#' The \code{attempts} argument instructs \code{crwMLE} to attempt a fit
+#' multiple times. Each time, the fit is inspected for convergance, whether
+#' the covariance matrix could be calculated, negative values in the diag 
+#' of the covariance matrix, or NA values in the standard errors. If, after
+#' n attempts, the fit is still not valid a \code{simpleError} object is
+#' returned. Users should consider increasing the number of attempts OR
+#' adjusting the standard deviation value for each attempt by setting
+#' \code{retrySD}. The default value for \code{retrySD} is 1, but users may
+#' need to increase or decrease to find a valid fit. Adjusting other
+#' model parameters may also be required.
+#' 
 #' @param mov.model formula object specifying the time indexed covariates for
 #' movement parameters.
 #' @param err.model A 2-element list of formula objects specifying the time
@@ -87,7 +98,7 @@
 #' @param initialSANN Control list for \code{\link{optim}} when simulated
 #' annealing is used for obtaining start values. See details
 #' @param attempts The number of times likelihood optimization will be
-#' attempted
+#' attempted in cases where the fit does not converge or is otherwise non-valid
 #' @param retrySD optional user-provided standard deviation for adjusting
 #' starting values when attempts > 1. Default value is 1.
 #' @param ... Additional arguments that are ignored.

--- a/R/fix_path.R
+++ b/R/fix_path.R
@@ -191,6 +191,7 @@ fix_segments <- function(crw_sf, vector_mask, barrier_buffer=50, crwFit,
       coast_hull_over <- coast_hull %>% 
         sf::st_intersects() %>% 
         purrr::map_int(length)
+      
       if (any(coast_hull_over > 1) & sum(diff(coast_hull_over)) != 0) {
         coast_hull <- coast_hull %>% 
           dplyr::slice(-which(coast_hull_over == max(coast_hull_over))) 
@@ -200,8 +201,7 @@ fix_segments <- function(crw_sf, vector_mask, barrier_buffer=50, crwFit,
           sf::st_cast() %>% sf::st_cast("POLYGON")
       }
       
-      coast_hull <- coast_hull %>% # for crwIS segment 51 has 2 very large polys
-   #     dplyr::slice(-which.max(sf::st_area(.))) %>% 
+      coast_hull <- coast_hull %>%  
         sf::st_buffer(barrier_buffer) %>% 
         sf::st_union() %>% 
         sf::st_union(fix_line) %>% 

--- a/R/fix_path.R
+++ b/R/fix_path.R
@@ -175,6 +175,7 @@ fix_segments <- function(crw_sf, vector_mask, barrier_buffer=50, crwFit,
     }
     
     if (n_polys != 0) {
+      suppressWarnings(
       coast_hull <- vector_mask %>%  
         dplyr::filter(lengths(sf::st_intersects(., fix_line)) > 0) %>% 
         sf::st_difference(sf::st_buffer(sf::st_intersection(fix_line,.),dist = 1)) %>%
@@ -185,6 +186,7 @@ fix_segments <- function(crw_sf, vector_mask, barrier_buffer=50, crwFit,
         sf::st_cast() %>% 
         sf::st_cast("POLYGON") %>% sf::st_sf() %>% 
         dplyr::slice(-which.max(sf::st_area(.)))
+      )
       
       coast_hull_over <- coast_hull %>% 
         sf::st_intersects() %>% 
@@ -399,9 +401,6 @@ fix_path <- function(crw_object, vector_mask, crwFit, quiet = TRUE) {
   vector_mask <- vector_mask %>% sf::st_buffer(0) %>% 
     sf::st_collection_extract(type = "POLYGON", warn = FALSE) %>% 
     sf::st_cast("POLYGON", warn = FALSE)
-  # %>% 
-  #   rmapshaper::ms_clip(bbox = sf::st_bbox(sf::st_buffer(crw_sf,100000)), 
-  #                       remove_slivers = TRUE)
   
   # intersect crw_sf with vector mask
   on_mask <- sf::st_intersects(crw_sf, vector_mask) %>% 
@@ -409,8 +408,8 @@ fix_path <- function(crw_object, vector_mask, crwFit, quiet = TRUE) {
   if (any(is.na(on_mask))) {
     stop("points in crw_sf fall outside the extent of vector_mask")
   }
-  # return NULL if no points within the vector mask
-  if (sum(on_mask,na.rm = TRUE) == 0) {return(NULL)}
+  # return the provided crw_object if no points within the vector mask
+  if (sum(on_mask,na.rm = TRUE) == 0) {return(crw_object)}
   
   head_start <- 1
   tail_end <- length(on_mask)


### PR DESCRIPTION
This is mostly an effort to improve multiple 'attempts' within `crwMLE()`.

When attempts is greater than 1, the fits are examined for errors associated with convergence, negatives in the diag of covariance matrix, etc. The theta parameter is also adjusted based on the retrySD argument each attempt. Hopefully, all of this results is more reliable fitting.

`crwMLE` now returns a `simpleError` when it fails to find a proper fit. IF a `crwFit` object is returned, then it should be valid.

PS: some minor fixes to `fix_path` snuck into this branch