### PR TITLE
ADD na.rm=TRUE for minor ellipse check

### DIFF
--- a/R/argosDiag2Cov.R
+++ b/R/argosDiag2Cov.R
@@ -17,7 +17,7 @@
 argosDiag2Cov = function(Major, Minor, Orientation){
   a=Major
   b=Minor
-  if(any(b<=.Machine$double.eps)) stop("There are very small (or 0) values for the minor ellipse lengths! These may need to be removed.")
+  if(any(b<=.Machine$double.eps,na.rm=TRUE)) stop("There are very small (or 0) values for the minor ellipse lengths! These may need to be removed.")
   theta=Orientation
   if(any(theta < 0 | theta > 180, na.rm = TRUE)) stop("Argos diagnostic data orientation outside of [0,180]!")
   if(any(a < 0, na.rm = TRUE)) stop("Argos diagnostic data major axis < 0!")


### PR DESCRIPTION
The check to make sure there aren't really small values for semi-minor axis values needed an na.rm=TRUE argument. 